### PR TITLE
Allow assert messages

### DIFF
--- a/testler.go
+++ b/testler.go
@@ -12,7 +12,7 @@ func Expect(t *testing.T, a interface{}, b interface{}, messages ...string) {
 		if len(messages) > 0 {
 			message = messages[0] + "\n"
 		}
-		t.Errorf("%vExpected %v (type %v) - Got %v (type %v)", message, b, reflect.TypeOf(b), a, reflect.TypeOf(a))
+		t.Errorf("%sExpected %v (type %v) - Got %v (type %v)", message, b, reflect.TypeOf(b), a, reflect.TypeOf(a))
 	}
 }
 
@@ -22,6 +22,6 @@ func Refute(t *testing.T, a interface{}, b interface{}, messages ...string) {
 		if len(messages) > 0 {
 			message = messages[0] + "\n"
 		}
-		t.Errorf("%vDid not expect %v (type %v) - Got %v (type %v)", message, b, reflect.TypeOf(b), a, reflect.TypeOf(a))
+		t.Errorf("%sDid not expect %v (type %v) - Got %v (type %v)", message, b, reflect.TypeOf(b), a, reflect.TypeOf(a))
 	}
 }

--- a/testler.go
+++ b/testler.go
@@ -6,14 +6,22 @@ import (
 )
 
 /* Test Helpers */
-func Expect(t *testing.T, a interface{}, b interface{}) {
+func Expect(t *testing.T, a interface{}, b interface{}, messages ...string) {
 	if a != b {
-		t.Errorf("Expected %v (type %v) - Got %v (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
+		var message string = ""
+		if len(messages) > 0 {
+			message = messages[0] + "\n"
+		}
+		t.Errorf("%vExpected %v (type %v) - Got %v (type %v)", message, b, reflect.TypeOf(b), a, reflect.TypeOf(a))
 	}
 }
 
-func Refute(t *testing.T, a interface{}, b interface{}) {
+func Refute(t *testing.T, a interface{}, b interface{}, messages ...string) {
 	if a == b {
-		t.Errorf("Did not expect %v (type %v) - Got %v (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
+		var message string = ""
+		if len(messages) > 0 {
+			message = messages[0] + "\n"
+		}
+		t.Errorf("%vDid not expect %v (type %v) - Got %v (type %v)", message, b, reflect.TypeOf(b), a, reflect.TypeOf(a))
 	}
 }

--- a/testler_test.go
+++ b/testler_test.go
@@ -24,6 +24,14 @@ func TestExpectString(t *testing.T) {
     Expect(t, "string", "string")
 }
 
+func TestExpectSuccessWithMessage(t *testing.T) {
+    Expect(t, true, true, "true should be true because: reasons")
+}
+
+func TestExpectFailWithMessage(t *testing.T) {
+    Expect(t, true, false, "true should be true because: reasons")
+}
+
 func TestRefuteTrue(t *testing.T) {
     Refute(t, true, false)
 }
@@ -42,4 +50,12 @@ func TestRefuteFloat(t *testing.T) {
 
 func TestRefuteString(t *testing.T) {
     Refute(t, "", "abra")
+}
+
+func TestRefuteSuccessWithMessage(t *testing.T) {
+    Refute(t, true, false, "true should definitely not be true because: reasons")
+}
+
+func TestRefuteFailWithMessage(t *testing.T) {
+    Refute(t, true, true, "true should definitely not be true because: reasons")
 }

--- a/testler_test.go
+++ b/testler_test.go
@@ -28,9 +28,11 @@ func TestExpectSuccessWithMessage(t *testing.T) {
     Expect(t, true, true, "true should be true because: reasons")
 }
 
+/*
 func TestExpectFailWithMessage(t *testing.T) {
     Expect(t, true, false, "true should be true because: reasons")
 }
+*/
 
 func TestRefuteTrue(t *testing.T) {
     Refute(t, true, false)
@@ -56,6 +58,8 @@ func TestRefuteSuccessWithMessage(t *testing.T) {
     Refute(t, true, false, "true should definitely not be true because: reasons")
 }
 
+/*
 func TestRefuteFailWithMessage(t *testing.T) {
     Refute(t, true, true, "true should definitely not be true because: reasons")
 }
+*/


### PR DESCRIPTION
This permits saying why something fails:

```
-> go test
--- FAIL: TestExpectFailWithMessage (0.00s)
    testler.go:15: true should be true because: reasons
        Expected false (type bool) - Got true (type bool)
--- FAIL: TestRefuteFailWithMessage (0.00s)
    testler.go:25: true should definitely not be true because: reasons
        Did not expect true (type bool) - Got true (type bool)
FAIL
exit status 1
FAIL    github.com/zackkitzmiller/testler   0.009s
-> 
```

Obviously in the tests here it's not particularly useful the kind of thing I have in mind is e.g.:

> After changing the users password - it shouldn't still be the same password
> Did not expect true (type bool) - Got true (type bool)

~~Needs revisions as I'm not sure how to correctly verify a test failure - there aren't any existing tests for that.~~ I just commented them out instead.
